### PR TITLE
NullPointer Catch not needed

### DIFF
--- a/src/at/ac/fhkufstein/Aufgabe_3.java
+++ b/src/at/ac/fhkufstein/Aufgabe_3.java
@@ -39,7 +39,7 @@ public class Aufgabe_3
         try
         {
             int i = Integer.parseInt(s);
-        } catch (NumberFormatException | NullPointerException ex)
+        } catch (NumberFormatException ex)
         {
             return false;
         }


### PR DESCRIPTION
NullPointer Catch not needed because Java gives it back as NumberFormatExc.